### PR TITLE
Add Focus Flow Flutter starter app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+flutter_*.png
+linked_*
+unlinked_*
+.dart-*
+.idea/
+android/
+ios/
+web/
+linux/
+macos/
+windows/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# VS Code related
+.vscode/
+
+# Misc
+*.log
+*.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# Testrepo
-test
+# Focus Flow
+
+Focus Flow is a Flutter starter application that helps you design healthier focus habits, tackle procrastination, and build momentum through intentional, time-boxed work. The app demonstrates a lightweight productivity framework with guided prompts and tools that you can expand into a full product.
+
+## Features
+
+- **Dashboard snapshot** – Track your completion streak, recent wins, weekly focus minutes, and upcoming checkpoints at a glance.
+- **Task planning workflow** – Break work into small, approachable focus tasks with priorities, estimated effort, due dates, and context tags.
+- **Focus timer** – Launch distraction-free sessions, choose preset or custom durations, and log every block to reinforce consistency.
+- **Insights and experiments** – Review focus history, celebrate wins, and receive adaptive suggestions to keep resistance low.
+- **State management with Provider** – A simple `ChangeNotifier` powers the app state so you can quickly extend the behavior.
+
+## Getting started
+
+1. Ensure you have [Flutter](https://docs.flutter.dev/get-started/install) installed (`flutter --version` should work).
+2. Fetch the dependencies:
+   ```bash
+   flutter pub get
+   ```
+3. Run the app on an emulator or device:
+   ```bash
+   flutter run
+   ```
+4. (Optional) Execute automated tests:
+   ```bash
+   flutter test
+   ```
+
+## Project structure
+
+```
+lib/
+├── main.dart                # Entry point and global theme
+├── models/                  # Task and focus session models
+├── state/app_state.dart     # Application state, stats, and sample data
+├── screens/                 # Feature screens (dashboard, tasks, timer, insights)
+└── widgets/                 # Reusable presentation components
+```
+
+## Extending the framework
+
+- Persist data by integrating `hive`, `sqflite`, or `shared_preferences` for local storage.
+- Connect to calendar or notification APIs so focus sessions reserve time on your schedule.
+- Expand analytics with charts (e.g., `fl_chart`) to visualize focus trends over time.
+- Introduce accountability by syncing progress with friends or mentors.
+
+## License
+
+This project is provided as a starting point for experimentation. Adapt it freely for personal projects.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
+    avoid_print: true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'screens/home_screen.dart';
+import 'state/app_state.dart';
+
+void main() {
+  runApp(const FocusFlowApp());
+}
+
+class FocusFlowApp extends StatelessWidget {
+  const FocusFlowApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = ColorScheme.fromSeed(seedColor: Colors.indigo);
+    return ChangeNotifierProvider<AppState>(
+      create: (_) => AppState(),
+      child: MaterialApp(
+        title: 'Focus Flow',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          colorScheme: colorScheme,
+          useMaterial3: true,
+          scaffoldBackgroundColor: colorScheme.surface,
+        ),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}
+

--- a/lib/models/focus_session.dart
+++ b/lib/models/focus_session.dart
@@ -1,0 +1,17 @@
+class FocusSession {
+  FocusSession({
+    required this.id,
+    required this.taskId,
+    required this.startedAt,
+    required this.durationMinutes,
+    this.completed = true,
+    this.note,
+  });
+
+  final String id;
+  final String taskId;
+  final DateTime startedAt;
+  final int durationMinutes;
+  final bool completed;
+  final String? note;
+}

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+/// Priority levels that help the user understand the urgency of a task.
+enum TaskPriority { low, medium, high }
+
+extension TaskPriorityExtension on TaskPriority {
+  String get label {
+    switch (this) {
+      case TaskPriority.low:
+        return 'Low';
+      case TaskPriority.medium:
+        return 'Medium';
+      case TaskPriority.high:
+        return 'High';
+    }
+  }
+
+  Color get color {
+    switch (this) {
+      case TaskPriority.low:
+        return Colors.green.shade300;
+      case TaskPriority.medium:
+        return Colors.orange.shade400;
+      case TaskPriority.high:
+        return Colors.red.shade400;
+    }
+  }
+}
+
+/// Representation of a focus task that the user wants to progress on.
+class Task {
+  Task({
+    required this.id,
+    required this.title,
+    required this.description,
+    this.dueDate,
+    this.tags = const <String>[],
+    this.estimatedMinutes = 25,
+    this.focusMinutes = 0,
+    this.priority = TaskPriority.medium,
+    this.isCompleted = false,
+    this.completedAt,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final DateTime? dueDate;
+  final List<String> tags;
+  final int estimatedMinutes;
+  final int focusMinutes;
+  final TaskPriority priority;
+  final bool isCompleted;
+  final DateTime? completedAt;
+
+  Task copyWith({
+    String? id,
+    String? title,
+    String? description,
+    DateTime? dueDate,
+    List<String>? tags,
+    int? estimatedMinutes,
+    int? focusMinutes,
+    TaskPriority? priority,
+    bool? isCompleted,
+    DateTime? completedAt,
+  }) {
+    return Task(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      dueDate: dueDate ?? this.dueDate,
+      tags: tags ?? this.tags,
+      estimatedMinutes: estimatedMinutes ?? this.estimatedMinutes,
+      focusMinutes: focusMinutes ?? this.focusMinutes,
+      priority: priority ?? this.priority,
+      isCompleted: isCompleted ?? this.isCompleted,
+      completedAt: completedAt ?? this.completedAt,
+    );
+  }
+
+  bool get isOverdue {
+    if (dueDate == null) {
+      return false;
+    }
+    final DateTime now = DateUtils.dateOnly(DateTime.now());
+    return dueDate!.isBefore(now) && !isCompleted;
+  }
+
+  bool get isDueToday {
+    if (dueDate == null) {
+      return false;
+    }
+    return DateUtils.isSameDay(dueDate, DateTime.now());
+  }
+
+  double get focusProgress {
+    if (estimatedMinutes <= 0) {
+      return 0;
+    }
+    return (focusMinutes / estimatedMinutes).clamp(0, 1).toDouble();
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,333 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/app_state.dart';
+import '../widgets/progress_ring.dart';
+
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (BuildContext context, AppState state, Widget? _) {
+        final ThemeData theme = Theme.of(context);
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: <Widget>[
+            Text(
+              'Daily momentum',
+              style: theme.textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            _buildStreakCard(context, state),
+            const SizedBox(height: 16),
+            _buildFocusSummary(context, state),
+            const SizedBox(height: 16),
+            _buildUpcomingTasks(context, state),
+            const SizedBox(height: 16),
+            _buildTagDistribution(context, state),
+            const SizedBox(height: 16),
+            _buildReflectionPrompt(context),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildStreakCard(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: <Widget>[
+            ProgressRing(
+              progress: state.completionRate,
+              color: theme.colorScheme.onPrimaryContainer,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Text(
+                    '${(state.completionRate * 100).round()}%',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    'Done',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Streak: ${state.streak} days',
+                    style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${state.completedToday} task(s) completed today',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  LinearProgressIndicator(
+                    value: state.focusMinutesThisWeek == 0
+                        ? 0
+                        : state.totalFocusMinutes == 0
+                            ? 0
+                            : state.focusMinutesThisWeek / state.totalFocusMinutes,
+                    minHeight: 8,
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Weekly focus: ${state.focusMinutesThisWeek} min',
+                    style: theme.textTheme.labelMedium,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFocusSummary(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Focus recommendations',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            if (state.activeTasks.isEmpty)
+              Text(
+                'You are all caught up! Take a mindful break or reflect on what helped you today.',
+                style: theme.textTheme.bodyMedium,
+              )
+            else
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Try a ${state.activeTasks.first.estimatedMinutes}-minute deep work sprint on:',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  _buildTaskHighlight(theme, state.activeTasks.first.title, state.activeTasks.first.description),
+                  if (state.activeTasks.length > 1) ...<Widget>[
+                    const SizedBox(height: 12),
+                    Text(
+                      'Need variety? Rotate with these tasks to keep your momentum fresh:',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: state.activeTasks
+                          .skip(1)
+                          .take(3)
+                          .map((task) => Chip(
+                                label: Text(task.title),
+                                backgroundColor: theme.colorScheme.surfaceVariant,
+                              ))
+                          .toList(),
+                    ),
+                  ],
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTaskHighlight(ThemeData theme, String title, String description) {
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            description,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUpcomingTasks(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Upcoming checkpoints',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            if (state.dueSoon.isEmpty)
+              Text(
+                'No urgent deadlines. Consider reviewing long-term goals or creating a new experiment.',
+                style: theme.textTheme.bodyMedium,
+              )
+            else
+              Column(
+                children: state.dueSoon
+                    .map((task) => ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(
+                            Icons.flag,
+                            color: task.priority.color,
+                          ),
+                          title: Text(task.title),
+                          subtitle: Text(
+                            task.description,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          trailing: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Text('${task.estimatedMinutes} min'),
+                              if (task.dueDate != null)
+                                Text(
+                                  _formatDueDate(task.dueDate!),
+                                  style: theme.textTheme.labelSmall,
+                                ),
+                            ],
+                          ),
+                        ))
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTagDistribution(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    final Map<String, double> distribution = state.tagDistribution;
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Energy mix',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            if (distribution.isEmpty)
+              Text(
+                'Tag your tasks to balance planning, execution, and restoration.',
+                style: theme.textTheme.bodyMedium,
+              )
+            else
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: distribution.entries
+                    .map(
+                      (MapEntry<String, double> entry) => Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          SizedBox(
+                            width: 80,
+                            child: LinearProgressIndicator(
+                              value: entry.value,
+                              minHeight: 8,
+                              borderRadius: const BorderRadius.all(Radius.circular(8)),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(entry.key, style: theme.textTheme.labelMedium),
+                          Text('${(entry.value * 100).round()}%',
+                              style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold)),
+                        ],
+                      ),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReflectionPrompt(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Reflection prompt',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'What helped you start today? Capture it before you forget so future-you has a playbook.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDueDate(DateTime dueDate) {
+    if (DateUtils.isSameDay(dueDate, DateTime.now())) {
+      return 'Today';
+    }
+    if (DateUtils.isSameDay(dueDate, DateTime.now().add(const Duration(days: 1)))) {
+      return 'Tomorrow';
+    }
+    return '${dueDate.month}/${dueDate.day}';
+  }
+}

--- a/lib/screens/focus_timer_screen.dart
+++ b/lib/screens/focus_timer_screen.dart
@@ -1,0 +1,334 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/task.dart';
+import '../state/app_state.dart';
+
+class FocusTimerScreen extends StatefulWidget {
+  const FocusTimerScreen({super.key});
+
+  @override
+  State<FocusTimerScreen> createState() => _FocusTimerScreenState();
+}
+
+class _FocusTimerScreenState extends State<FocusTimerScreen> {
+  Timer? _timer;
+  Duration _selectedDuration = const Duration(minutes: 25);
+  Duration _remaining = const Duration(minutes: 25);
+  bool _isRunning = false;
+  String? _selectedTaskId;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppState state = context.watch<AppState>();
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            'Focus timer',
+            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Pick a task, choose your sprint length, and start a distraction-free block.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 24),
+          _buildTaskPicker(state),
+          const SizedBox(height: 24),
+          _buildDurationSelector(context),
+          const SizedBox(height: 24),
+          Expanded(
+            child: Center(
+              child: _buildTimer(theme),
+            ),
+          ),
+          const SizedBox(height: 24),
+          _buildControls(theme),
+          const SizedBox(height: 12),
+          _buildSessionTips(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTaskPicker(AppState state) {
+    final List<Task> tasks = state.activeTasks;
+    return DropdownButtonFormField<String>(
+      value: _selectedTaskId,
+      hint: const Text('Select focus task'),
+      items: tasks
+          .map(
+            (Task task) => DropdownMenuItem<String>(
+              value: task.id,
+              child: Text(task.title),
+            ),
+          )
+          .toList(),
+      onChanged: (String? value) {
+        setState(() {
+          _selectedTaskId = value;
+        });
+      },
+    );
+  }
+
+  Widget _buildDurationSelector(BuildContext context) {
+    final List<Widget> chips = _presetDurations
+        .map((int minutes) => ChoiceChip(
+              label: Text('$minutes min'),
+              selected: _selectedDuration.inMinutes == minutes,
+              onSelected: (bool selected) {
+                if (!selected) {
+                  return;
+                }
+                setState(() {
+                  _selectedDuration = Duration(minutes: minutes);
+                  _remaining = _selectedDuration;
+                });
+              },
+            ))
+        .toList();
+    chips.add(
+      ChoiceChip(
+        label: const Text('Custom'),
+        selected: !_presetDurations.contains(_selectedDuration.inMinutes),
+        onSelected: (_) async {
+          final int? customMinutes = await _askForCustomDuration(context);
+          if (customMinutes != null) {
+            setState(() {
+              _selectedDuration = Duration(minutes: customMinutes);
+              _remaining = _selectedDuration;
+            });
+          }
+        },
+      ),
+    );
+    return Wrap(
+      spacing: 12,
+      children: chips,
+    );
+  }
+
+  Widget _buildTimer(ThemeData theme) {
+    final int totalSeconds = _selectedDuration.inSeconds;
+    final double progress = totalSeconds == 0
+        ? 0
+        : 1 - (_remaining.inSeconds / totalSeconds).clamp(0.0, 1.0);
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: 260,
+      height: 260,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: <Color>[
+            theme.colorScheme.primary.withOpacity(0.15),
+            theme.colorScheme.primary.withOpacity(0.05),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(200),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: <Widget>[
+          SizedBox(
+            width: 220,
+            height: 220,
+            child: CircularProgressIndicator(
+              value: progress,
+              strokeWidth: 12,
+            ),
+          ),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                _formatDuration(_remaining),
+                style: theme.textTheme.displaySmall?.copyWith(
+                  fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(_isRunning ? 'You are in the zone' : 'Ready when you are'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildControls(ThemeData theme) {
+    final bool hasSelection = _selectedTaskId != null;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        ElevatedButton.icon(
+          onPressed: hasSelection ? (_isRunning ? _pause : _start) : _promptForTask,
+          icon: Icon(_isRunning ? Icons.pause : Icons.play_arrow),
+          label: Text(_isRunning ? 'Pause' : 'Start focus'),
+        ),
+        const SizedBox(width: 12),
+        OutlinedButton.icon(
+          onPressed: _isRunning ? () => _completeSession(auto: false) : _reset,
+          icon: Icon(_isRunning ? Icons.flag : Icons.restart_alt),
+          label: Text(_isRunning ? 'Finish early' : 'Reset'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSessionTips(ThemeData theme) {
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const <Widget>[
+          Text(
+            'Micro-commitment tip',
+            style: TextStyle(fontWeight: FontWeight.w600),
+          ),
+          SizedBox(height: 6),
+          Text(
+            'Silence notifications, write down your starting action, and promise yourself a break when the timer ends.',
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _start() {
+    setState(() {
+      _isRunning = true;
+      _remaining = _selectedDuration;
+    });
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (Timer timer) {
+      if (_remaining.inSeconds <= 1) {
+        timer.cancel();
+        _completeSession(auto: true);
+      } else {
+        setState(() {
+          _remaining -= const Duration(seconds: 1);
+        });
+      }
+    });
+  }
+
+  void _pause() {
+    _timer?.cancel();
+    setState(() {
+      _isRunning = false;
+    });
+  }
+
+  void _reset() {
+    _timer?.cancel();
+    setState(() {
+      _isRunning = false;
+      _remaining = _selectedDuration;
+    });
+  }
+
+  void _completeSession({required bool auto}) {
+    _timer?.cancel();
+    final String? taskId = _selectedTaskId;
+    if (taskId == null) {
+      _reset();
+      return;
+    }
+    final int loggedMinutes = auto
+        ? _selectedDuration.inMinutes
+        : (_selectedDuration - _remaining).inMinutes;
+    final int safeMinutes = loggedMinutes <= 0 ? 1 : loggedMinutes;
+    final AppState state = context.read<AppState>();
+    state.addFocusSession(
+      taskId: taskId,
+      duration: Duration(minutes: safeMinutes),
+      completed: auto,
+      note: auto ? 'Completed focus block' : 'Stopped early',
+    );
+    setState(() {
+      _isRunning = false;
+      _remaining = _selectedDuration;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          auto
+              ? 'Nice work! Log a quick win before moving on.'
+              : 'Session saved. Consider adjusting the duration next time.',
+        ),
+      ),
+    );
+  }
+
+  void _promptForTask() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Select a task to stay intentional.')),
+    );
+  }
+
+  String _formatDuration(Duration duration) {
+    final String minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final String seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    if (duration.inHours > 0) {
+      return '${duration.inHours.toString().padLeft(2, '0')}:$minutes:$seconds';
+    }
+    return '$minutes:$seconds';
+  }
+
+  List<int> get _presetDurations => const <int>[15, 25, 45];
+
+  Future<int?> _askForCustomDuration(BuildContext context) async {
+    final TextEditingController controller =
+        TextEditingController(text: _selectedDuration.inMinutes.toString());
+    final int? result = await showDialog<int>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Custom duration'),
+          content: TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(hintText: 'Minutes'),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final int? value = int.tryParse(controller.text);
+                if (value == null || value <= 0) {
+                  return;
+                }
+                Navigator.of(context).pop(value);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+    return result;
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import 'dashboard_screen.dart';
+import 'focus_timer_screen.dart';
+import 'insights_screen.dart';
+import 'tasks_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _index = 0;
+
+  final List<Widget> _pages = const <Widget>[
+    DashboardScreen(),
+    TasksScreen(),
+    FocusTimerScreen(),
+    InsightsScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Focus Flow'),
+      ),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        child: KeyedSubtree(
+          key: ValueKey<int>(_index),
+          child: _pages[_index],
+        ),
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _index,
+        onDestinationSelected: (int newIndex) {
+          setState(() {
+            _index = newIndex;
+          });
+        },
+        destinations: const <NavigationDestination>[
+          NavigationDestination(
+            icon: Icon(Icons.dashboard_outlined),
+            selectedIcon: Icon(Icons.dashboard),
+            label: 'Dashboard',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.checklist_rtl),
+            selectedIcon: Icon(Icons.checklist),
+            label: 'Tasks',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.hourglass_empty),
+            selectedIcon: Icon(Icons.hourglass_full),
+            label: 'Focus',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.insights_outlined),
+            selectedIcon: Icon(Icons.insights),
+            label: 'Insights',
+          ),
+        ],
+      ),
+      backgroundColor: theme.colorScheme.surface,
+    );
+  }
+}

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/focus_session.dart';
+import '../models/task.dart';
+import '../state/app_state.dart';
+
+class InsightsScreen extends StatelessWidget {
+  const InsightsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (BuildContext context, AppState state, Widget? _) {
+        final ThemeData theme = Theme.of(context);
+        final List<String> suggestions = _buildSuggestions(state);
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: <Widget>[
+            Text(
+              'Progress pulse',
+              style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            _buildStatHighlights(context, state),
+            const SizedBox(height: 16),
+            _buildRecentSessions(context, state),
+            const SizedBox(height: 16),
+            _buildWins(context, state),
+            const SizedBox(height: 16),
+            _buildSuggestionsCard(context, suggestions),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildStatHighlights(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: _StatTile(
+                label: 'Completion rate',
+                value: '${(state.completionRate * 100).round()}%',
+                contextText: '${state.completedTasks.length}/${state.tasks.length} tasks',
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _StatTile(
+                label: 'Weekly focus',
+                value: '${state.focusMinutesThisWeek} min',
+                contextText: 'Lifetime ${state.totalFocusMinutes} min',
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _StatTile(
+                label: 'Momentum streak',
+                value: '${state.streak} days',
+                contextText: state.streak >= 3
+                    ? 'Keep stacking wins'
+                    : 'Complete a task tomorrow',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecentSessions(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    final List<FocusSession> sessions = state.recentSessions;
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Recent focus logs',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            if (sessions.isEmpty)
+              Text(
+                'Start the timer to create a streak of completed focus blocks.',
+                style: theme.textTheme.bodyMedium,
+              )
+            else
+              Column(
+                children: sessions
+                    .map(
+                      (FocusSession session) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.self_improvement),
+                        title: Text('${session.durationMinutes} minute block'),
+                        subtitle: Text(_formatSessionSubtitle(context, session)),
+                        trailing: Icon(
+                          session.completed ? Icons.check_circle : Icons.flag,
+                          color: session.completed
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.secondary,
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWins(BuildContext context, AppState state) {
+    final ThemeData theme = Theme.of(context);
+    final List<Task> completed = state.completedTasks.take(3).toList();
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Momentum wins',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            if (completed.isEmpty)
+              Text(
+                'Complete one micro-task today so you can capture it here tomorrow.',
+                style: theme.textTheme.bodyMedium,
+              )
+            else
+              Column(
+                children: completed
+                    .map(
+                      (task) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: Icon(Icons.emoji_events, color: task.priority.color),
+                        title: Text(task.title),
+                        subtitle: Text(task.description, maxLines: 2, overflow: TextOverflow.ellipsis),
+                      ),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSuggestionsCard(BuildContext context, List<String> suggestions) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Suggested experiments',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (final String idea in suggestions)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    const Text('• '),
+                    Expanded(
+                      child: Text(
+                        idea,
+                        style: theme.textTheme.bodyMedium
+                            ?.copyWith(color: theme.colorScheme.onSecondaryContainer),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<String> _buildSuggestions(AppState state) {
+    final List<String> suggestions = <String>[];
+    if (state.completionRate < 0.5 && state.activeTasks.length >= 3) {
+      suggestions.add('Pick your top three priorities tonight so you start tomorrow with clarity.');
+    }
+    if (state.focusMinutesThisWeek < 60) {
+      suggestions.add('Schedule two 25-minute focus sessions and guard them like meetings with yourself.');
+    }
+    if (state.streak < 3) {
+      suggestions.add('Complete one tiny task before noon to rebuild your streak early in the day.');
+    } else {
+      suggestions.add('Celebrate your streak by noting the rituals that make starting easier.');
+    }
+    if (suggestions.isEmpty()) {
+      suggestions.add('You are building strong habits. Try mentoring a friend or documenting your playbook.');
+    }
+    return suggestions;
+  }
+
+  String _formatSessionSubtitle(BuildContext context, FocusSession session) {
+    final DateTime now = DateTime.now();
+    final Duration diff = now.difference(session.startedAt);
+    final TimeOfDay time = TimeOfDay.fromDateTime(session.startedAt);
+    String timeLabel = time.format(context);
+    if (diff.inDays == 0) {
+      return 'Today • $timeLabel';
+    }
+    if (diff.inDays == 1) {
+      return 'Yesterday • $timeLabel';
+    }
+    return '${session.startedAt.month}/${session.startedAt.day}/${session.startedAt.year} • $timeLabel';
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.label,
+    required this.value,
+    required this.contextText,
+  });
+
+  final String label;
+  final String value;
+  final String contextText;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(label, style: theme.textTheme.labelMedium),
+        const SizedBox(height: 6),
+        Text(
+          value,
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(contextText, style: theme.textTheme.bodySmall),
+      ],
+    );
+  }
+}

--- a/lib/screens/tasks_screen.dart
+++ b/lib/screens/tasks_screen.dart
@@ -1,0 +1,423 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/task.dart';
+import '../state/app_state.dart';
+
+enum TaskFilter { all, active, completed }
+
+class TasksScreen extends StatefulWidget {
+  const TasksScreen({super.key});
+
+  @override
+  State<TasksScreen> createState() => _TasksScreenState();
+}
+
+class _TasksScreenState extends State<TasksScreen> {
+  TaskFilter _filter = TaskFilter.active;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppState appState = context.watch<AppState>();
+    final List<Task> tasks = _applyFilter(appState);
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openTaskComposer(context),
+        icon: const Icon(Icons.add_task),
+        label: const Text('New task'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  'Plan your focus',
+                  style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                SegmentedButton<TaskFilter>(
+                  segments: const <ButtonSegment<TaskFilter>>[
+                    ButtonSegment<TaskFilter>(value: TaskFilter.active, label: Text('Active')),
+                    ButtonSegment<TaskFilter>(value: TaskFilter.completed, label: Text('Done')),
+                    ButtonSegment<TaskFilter>(value: TaskFilter.all, label: Text('All')),
+                  ],
+                  selected: <TaskFilter>{_filter},
+                  onSelectionChanged: (Set<TaskFilter> selection) {
+                    setState(() {
+                      _filter = selection.first;
+                    });
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (tasks.isEmpty)
+              Expanded(
+                child: Center(
+                  child: Text(
+                    _emptyLabel(),
+                    style: theme.textTheme.bodyLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              )
+            else
+              Expanded(
+                child: ListView.separated(
+                  itemBuilder: (BuildContext context, int index) {
+                    final Task task = tasks[index];
+                    return _TaskTile(task: task);
+                  },
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemCount: tasks.length,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Task> _applyFilter(AppState state) {
+    switch (_filter) {
+      case TaskFilter.all:
+        return state.tasks.toList();
+      case TaskFilter.active:
+        return state.activeTasks;
+      case TaskFilter.completed:
+        return state.completedTasks;
+    }
+  }
+
+  String _emptyLabel() {
+    switch (_filter) {
+      case TaskFilter.all:
+        return 'No tasks yet. Create one experiment to try today.';
+      case TaskFilter.active:
+        return 'All tasks are complete! Celebrate and schedule your next focus block.';
+      case TaskFilter.completed:
+        return 'Once you complete tasks, they will show up here.';
+    }
+  }
+
+  Future<void> _openTaskComposer(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) => const _TaskComposerSheet(),
+    );
+  }
+}
+
+class _TaskTile extends StatelessWidget {
+  const _TaskTile({required this.task});
+
+  final Task task;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppState state = context.read<AppState>();
+    final ThemeData theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surface,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: () => state.toggleTaskCompletion(task.id),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Checkbox(
+                value: task.isCompleted,
+                onChanged: (_) => state.toggleTaskCompletion(task.id),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: Text(
+                            task.title,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              decoration: task.isCompleted
+                                  ? TextDecoration.lineThrough
+                                  : TextDecoration.none,
+                            ),
+                          ),
+                        ),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: task.priority.color.withOpacity(0.15),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            task.priority.label,
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: task.priority.color,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      task.description,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: <Widget>[
+                        Icon(Icons.timer_outlined, size: 18, color: theme.colorScheme.primary),
+                        const SizedBox(width: 4),
+                        Text('${task.focusMinutes}/${task.estimatedMinutes} min'),
+                        if (task.dueDate != null) ...<Widget>[
+                          const SizedBox(width: 12),
+                          Icon(Icons.event, size: 18, color: theme.colorScheme.secondary),
+                          const SizedBox(width: 4),
+                          Text(
+                            _formatDue(task.dueDate!),
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ],
+                    ),
+                    if (task.tags.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: task.tags
+                            .map(
+                              (String tag) => Chip(
+                                label: Text('#$tag'),
+                                backgroundColor: theme.colorScheme.surfaceVariant,
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDue(DateTime dueDate) {
+    final DateTime today = DateUtils.dateOnly(DateTime.now());
+    if (DateUtils.isSameDay(today, dueDate)) {
+      return 'Due today';
+    }
+    if (dueDate.isBefore(today)) {
+      return 'Overdue';
+    }
+    return 'Due ${dueDate.month}/${dueDate.day}';
+  }
+}
+
+class _TaskComposerSheet extends StatefulWidget {
+  const _TaskComposerSheet();
+
+  @override
+  State<_TaskComposerSheet> createState() => _TaskComposerSheetState();
+}
+
+class _TaskComposerSheetState extends State<_TaskComposerSheet> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _tagsController = TextEditingController();
+  final TextEditingController _minutesController = TextEditingController(text: '25');
+  DateTime? _dueDate;
+  TaskPriority _priority = TaskPriority.medium;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _tagsController.dispose();
+    _minutesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final double bottomPadding = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomPadding),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  Text(
+                    'Create focus task',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).maybePop(),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(labelText: 'Title'),
+                validator: (String? value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Add a clear title to reduce resistance.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(labelText: 'Description'),
+                maxLines: 3,
+                validator: (String? value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Describe the first action you will take.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: TextFormField(
+                      controller: _minutesController,
+                      decoration: const InputDecoration(labelText: 'Estimated minutes'),
+                      keyboardType: TextInputType.number,
+                      validator: (String? value) {
+                        final int? minutes = int.tryParse(value ?? '');
+                        if (minutes == null || minutes <= 0) {
+                          return 'Estimate a realistic focus block.';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: InkWell(
+                      onTap: _pickDueDate,
+                      child: InputDecorator(
+                        decoration: const InputDecoration(labelText: 'Due date'),
+                        child: Text(_dueDate == null
+                            ? 'Optional'
+                            : '${_dueDate!.month}/${_dueDate!.day}/${_dueDate!.year}'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<TaskPriority>(
+                value: _priority,
+                decoration: const InputDecoration(labelText: 'Priority'),
+                items: TaskPriority.values
+                    .map(
+                      (TaskPriority priority) => DropdownMenuItem<TaskPriority>(
+                        value: priority,
+                        child: Text(priority.label),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (TaskPriority? value) {
+                  if (value != null) {
+                    setState(() {
+                      _priority = value;
+                    });
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _tagsController,
+                decoration: const InputDecoration(
+                  labelText: 'Tags',
+                  helperText: 'Separate tags with commas (e.g. planning, writing)',
+                ),
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: _submit,
+                  icon: const Icon(Icons.rocket_launch),
+                  label: const Text('Start momentum'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickDueDate() async {
+    final DateTime now = DateTime.now();
+    final DateTime? selected = await showDatePicker(
+      context: context,
+      initialDate: _dueDate ?? now,
+      firstDate: now.subtract(const Duration(days: 365)),
+      lastDate: now.add(const Duration(days: 365)),
+    );
+    if (selected != null) {
+      setState(() {
+        _dueDate = selected;
+      });
+    }
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final AppState state = context.read<AppState>();
+    final List<String> tags = _tagsController.text
+        .split(',')
+        .map((String tag) => tag.trim())
+        .where((String tag) => tag.isNotEmpty)
+        .toList();
+    final int minutes = int.tryParse(_minutesController.text) ?? 25;
+    state.createTask(
+      title: _titleController.text.trim(),
+      description: _descriptionController.text.trim(),
+      dueDate: _dueDate,
+      tags: tags,
+      estimatedMinutes: minutes,
+      priority: _priority,
+    );
+    Navigator.of(context).maybePop();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Task added. Schedule a focus block to follow through.')),
+    );
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1,0 +1,230 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+
+import '../models/focus_session.dart';
+import '../models/task.dart';
+
+class AppState extends ChangeNotifier {
+  AppState() {
+    _seedTasks();
+  }
+
+  final List<Task> _tasks = <Task>[];
+  final List<FocusSession> _sessions = <FocusSession>[];
+  DateTime? _lastCompletionDate;
+  int _streak = 0;
+
+  UnmodifiableListView<Task> get tasks => UnmodifiableListView<Task>(_tasks);
+  UnmodifiableListView<FocusSession> get sessions => UnmodifiableListView<FocusSession>(_sessions);
+
+  int get streak => _streak;
+
+  double get completionRate {
+    if (_tasks.isEmpty) {
+      return 0;
+    }
+    final int completedCount = _tasks.where((Task task) => task.isCompleted).length;
+    return completedCount / _tasks.length;
+  }
+
+  int get completedToday {
+    final DateTime today = DateUtils.dateOnly(DateTime.now());
+    return _tasks
+        .where((Task task) =>
+            task.completedAt != null && DateUtils.isSameDay(task.completedAt, today))
+        .length;
+  }
+
+  int get focusMinutesThisWeek {
+    if (_sessions.isEmpty) {
+      return 0;
+    }
+    final DateTime now = DateTime.now();
+    final DateTime startOfWeek = DateUtils.dateOnly(now.subtract(Duration(days: now.weekday - 1)));
+    return _sessions
+        .where((FocusSession session) =>
+            !session.startedAt.isBefore(startOfWeek) && session.completed)
+        .fold<int>(0, (int sum, FocusSession session) => sum + session.durationMinutes);
+  }
+
+  int get totalPlannedMinutes => _tasks
+      .where((Task task) => !task.isCompleted)
+      .fold<int>(0, (int sum, Task task) => sum + task.estimatedMinutes);
+
+  int get totalFocusMinutes => _sessions.fold<int>(
+        0,
+        (int sum, FocusSession session) => sum + session.durationMinutes,
+      );
+
+  List<Task> get activeTasks =>
+      _tasks.where((Task task) => !task.isCompleted).toList(growable: false);
+
+  List<Task> get completedTasks =>
+      _tasks.where((Task task) => task.isCompleted).toList(growable: false);
+
+  List<Task> get dueSoon {
+    final List<Task> upcoming = _tasks
+        .where((Task task) =>
+            !task.isCompleted && task.dueDate != null &&
+            task.dueDate!.isBefore(DateTime.now().add(const Duration(days: 3))))
+        .toList();
+    upcoming.sort((Task a, Task b) => a.dueDate!.compareTo(b.dueDate!));
+    return upcoming.take(5).toList();
+  }
+
+  Map<String, double> get tagDistribution {
+    final Map<String, int> counts = <String, int>{};
+    for (final Task task in _tasks) {
+      for (final String tag in task.tags) {
+        counts.update(tag, (int value) => value + 1, ifAbsent: () => 1);
+      }
+    }
+    if (counts.isEmpty) {
+      return <String, double>{};
+    }
+    final int total = counts.values.fold<int>(0, (int sum, int count) => sum + count);
+    return counts.map<String, double>((String key, int value) {
+      return MapEntry<String, double>(key, value / total);
+    });
+  }
+
+  List<FocusSession> get recentSessions {
+    final List<FocusSession> recent = List<FocusSession>.from(_sessions);
+    recent.sort((FocusSession a, FocusSession b) => b.startedAt.compareTo(a.startedAt));
+    return recent.take(10).toList();
+  }
+
+  void addTask(Task task) {
+    _tasks.add(task);
+    notifyListeners();
+  }
+
+  void createTask({
+    required String title,
+    required String description,
+    DateTime? dueDate,
+    List<String> tags = const <String>[],
+    int estimatedMinutes = 25,
+    TaskPriority priority = TaskPriority.medium,
+  }) {
+    final Task task = Task(
+      id: _generateId(),
+      title: title,
+      description: description,
+      dueDate: dueDate,
+      tags: List<String>.from(tags),
+      estimatedMinutes: estimatedMinutes,
+      priority: priority,
+    );
+    addTask(task);
+  }
+
+  void toggleTaskCompletion(String taskId) {
+    final int index = _tasks.indexWhere((Task task) => task.id == taskId);
+    if (index == -1) {
+      return;
+    }
+    final Task current = _tasks[index];
+    final bool nextCompletedState = !current.isCompleted;
+    final Task updated = current.copyWith(
+      isCompleted: nextCompletedState,
+      completedAt: nextCompletedState ? DateTime.now() : null,
+    );
+    _tasks[index] = updated;
+    if (nextCompletedState) {
+      _updateStreak(DateTime.now());
+    }
+    notifyListeners();
+  }
+
+  void addFocusSession({
+    required String taskId,
+    required Duration duration,
+    bool completed = true,
+    String? note,
+  }) {
+    final FocusSession session = FocusSession(
+      id: _generateId(),
+      taskId: taskId,
+      startedAt: DateTime.now(),
+      durationMinutes: duration.inMinutes,
+      completed: completed,
+      note: note,
+    );
+    _sessions.add(session);
+    final int taskIndex = _tasks.indexWhere((Task task) => task.id == taskId);
+    if (taskIndex != -1) {
+      final Task task = _tasks[taskIndex];
+      _tasks[taskIndex] = task.copyWith(
+        focusMinutes: task.focusMinutes + duration.inMinutes,
+      );
+    }
+    if (completed) {
+      _updateStreak(DateTime.now());
+    }
+    notifyListeners();
+  }
+
+  void _seedTasks() {
+    if (_tasks.isNotEmpty) {
+      return;
+    }
+    final DateTime today = DateUtils.dateOnly(DateTime.now());
+    addTask(
+      Task(
+        id: _generateId(),
+        title: 'Break down your next milestone',
+        description:
+            'Outline the smallest actionable steps needed for your next milestone so it feels less intimidating.',
+        dueDate: today,
+        estimatedMinutes: 35,
+        tags: const <String>['planning', 'clarity'],
+        priority: TaskPriority.high,
+      ),
+    );
+    addTask(
+      Task(
+        id: _generateId(),
+        title: 'Schedule focus blocks',
+        description:
+            'Block out two 25-minute focus sessions on your calendar and protect them from interruptions.',
+        dueDate: today.add(const Duration(days: 1)),
+        estimatedMinutes: 15,
+        tags: const <String>['routine'],
+        priority: TaskPriority.medium,
+      ),
+    );
+    addTask(
+      Task(
+        id: _generateId(),
+        title: 'Reflect on progress',
+        description:
+            'Write down one win, one challenge, and one experiment you will try tomorrow to keep momentum.',
+        dueDate: today.add(const Duration(days: 2)),
+        estimatedMinutes: 20,
+        tags: const <String>['reflection'],
+        priority: TaskPriority.low,
+      ),
+    );
+  }
+
+  void _updateStreak(DateTime completionDateTime) {
+    final DateTime completionDay = DateUtils.dateOnly(completionDateTime);
+    if (_lastCompletionDate == null) {
+      _streak = 1;
+    } else {
+      final int difference = completionDay.difference(_lastCompletionDate!).inDays;
+      if (difference == 0) {
+        // Same day completion keeps the streak as-is.
+      } else if (difference == 1) {
+        _streak += 1;
+      } else if (difference > 1) {
+        _streak = 1;
+      }
+    }
+    _lastCompletionDate = completionDay;
+  }
+
+  String _generateId() => DateTime.now().microsecondsSinceEpoch.toString();
+}

--- a/lib/widgets/progress_ring.dart
+++ b/lib/widgets/progress_ring.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class ProgressRing extends StatelessWidget {
+  const ProgressRing({
+    super.key,
+    required this.progress,
+    this.size = 96,
+    this.color,
+    this.child,
+  });
+
+  final double progress;
+  final double size;
+  final Color? color;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color effectiveColor = color ?? Theme.of(context).colorScheme.primary;
+    final double clampedProgress = progress.clamp(0, 1);
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: <Widget>[
+          CircularProgressIndicator(
+            value: clampedProgress,
+            strokeWidth: 8,
+            backgroundColor: effectiveColor.withOpacity(0.1),
+            valueColor: AlwaysStoppedAnimation<Color>(effectiveColor),
+          ),
+          child ??
+              Text(
+                '${(clampedProgress * 100).round()}%',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: effectiveColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: focus_flow
+description: A Flutter framework-style starter app that helps people manage and overcome procrastination.
+publish_to: "none"
+version: 0.1.0
+
+environment:
+  sdk: ">=2.19.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  provider: ^6.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold a Flutter application with Provider-managed state and a home shell for dashboard, tasks, focus timer, and insights experiences
- implement procrastination-focused workflows including task planning, adaptive focus timer logging, and insight suggestions
- document setup instructions and project structure for extending the framework

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68cb36f242e0832fac7826f969847426